### PR TITLE
Closes #1 login from multiple clients

### DIFF
--- a/backend/TODO.md
+++ b/backend/TODO.md
@@ -2,5 +2,6 @@
 - [x] Set userToken and clientToken on register
 - [x] Set clientToken and userToken on login
 - [ ] If logged in from other client, only update clientToken on login
-- [ ] Update ValidateToken to follow new pattern
+- [x] Update ValidateToken to follow new pattern
 - [x] Move expiry date to client token
+- [ ] Update RemoveToken to follow new pattern

--- a/backend/TODO.md
+++ b/backend/TODO.md
@@ -3,4 +3,4 @@
 - [x] Set clientToken and userToken on login
 - [ ] If logged in from other client, only update clientToken on login
 - [ ] Update ValidateToken to follow new pattern
-- [ ] Move expiry date to client token
+- [x] Move expiry date to client token

--- a/backend/TODO.md
+++ b/backend/TODO.md
@@ -1,7 +1,7 @@
 # TODO Backend
 - [x] Set userToken and clientToken on register
 - [x] Set clientToken and userToken on login
-- [ ] If logged in from other client, only update clientToken on login
+- [x] If logged in from other client, only update clientToken on login
 - [x] Update ValidateToken to follow new pattern
 - [x] Move expiry date to client token
-- [ ] Update RemoveToken to follow new pattern
+- [x] Update RemoveToken to follow new pattern

--- a/backend/auth_handlers.go
+++ b/backend/auth_handlers.go
@@ -98,7 +98,7 @@ func (v *ValidateTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	userInformation := s.GetUserWithAuthToken(request.AuthToken)
+	userInformation := s.GetUserWithAuthToken(request.AuthToken, GetRequestIP(r))
 	if userInformation == nil {
 		Unauthorized(w)
 		return

--- a/backend/auth_handlers.go
+++ b/backend/auth_handlers.go
@@ -98,8 +98,14 @@ func (v *ValidateTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	userInformation := s.GetUserWithAuthToken(request.AuthToken, GetRequestIP(r))
+	userInformation := s.GetUserWithAuthToken(request.AuthToken)
 	if userInformation == nil {
+		Unauthorized(w)
+		return
+	}
+
+	valid := s.ValidateToken(request.AuthToken, GetRequestIP(r), userInformation.Email)
+	if !valid {
 		Unauthorized(w)
 		return
 	}
@@ -152,7 +158,7 @@ func (h *SignOutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.RemoveAuthToken(request.Email)
+	s.RemoveAuthToken(request.Email, GetRequestIP(r))
 
 	WriteJSON(w, SignOutResponse{
 		ResponseCode:    200,

--- a/backend/db/db_types.go
+++ b/backend/db/db_types.go
@@ -6,30 +6,36 @@ import (
 )
 
 type User struct {
-	Email           string `json:"email"`
-	Password        string `json:"password"`
-	Name            string `json:"name"`
-	Surname         string `json:"surname"`
+	Email     string `json:"email"`
+	Password  string `json:"password"`
+	Name      string `json:"name"`
+	Surname   string `json:"surname"`
+	Id        int    `json:"id"`
+	AuthToken string `json:"auth_token"`
+}
+
+type AuthKey struct {
 	Id              int    `json:"id"`
-	AuthToken       string `json:"auth_token"`
+	IpAddr          string `json:"ip_addr"`
+	UserToken       string `json:"user_token"`
+	ClientToken     string `json:"client_token"`
 	TokenExpiryDate int64  `json:"token_expiry_date"`
 }
 
 func (user *User) ToString() string {
-	return fmt.Sprintf("Email: %s\nPassword: %s\nName: %s\nSurname: %s\nId: %d\nAuthToken: %s\nTokenExpiryDate: %d",
+	return fmt.Sprintf("Email: %s\nPassword: %s\nName: %s\nSurname: %s\nId: %d\nAuthToken: %s\n",
 		user.Email,
 		user.Password,
 		user.Name,
 		user.Surname,
 		user.Id,
-		user.AuthToken,
-		user.TokenExpiryDate)
+		user.AuthToken)
 }
 
 func DbEntryToUser(row *sql.Rows) *User {
 	selectedUser := &User{}
 	for row.Next() {
-		row.Scan(&selectedUser.Id, &selectedUser.Email, &selectedUser.Password, &selectedUser.Name, &selectedUser.Surname, &selectedUser.AuthToken, &selectedUser.TokenExpiryDate)
+		row.Scan(&selectedUser.Id, &selectedUser.Email, &selectedUser.Password, &selectedUser.Name, &selectedUser.Surname, &selectedUser.AuthToken)
 	}
 	if selectedUser.Name == "" {
 		return nil
@@ -37,6 +43,16 @@ func DbEntryToUser(row *sql.Rows) *User {
 	return selectedUser
 }
 
+func DbEntryToAuthKey(row *sql.Rows) *AuthKey {
+	authKey := &AuthKey{}
+	for row.Next() {
+		row.Scan(&authKey.Id, &authKey.IpAddr, &authKey.UserToken, &authKey.ClientToken, &authKey.TokenExpiryDate)
+	}
+	if authKey.UserToken == "" {
+		return nil
+	}
+	return authKey
+}
 func DbEntryToHostNames(rows *sql.Rows) []string {
 	hostNames := []string{}
 	for rows.Next() {

--- a/backend/db/db_types.go
+++ b/backend/db/db_types.go
@@ -6,12 +6,13 @@ import (
 )
 
 type User struct {
-	Email     string `json:"email"`
-	Password  string `json:"password"`
-	Name      string `json:"name"`
-	Surname   string `json:"surname"`
-	Id        int    `json:"id"`
-	AuthToken string `json:"auth_token"`
+	Email         string `json:"email"`
+	Password      string `json:"password"`
+	Name          string `json:"name"`
+	Surname       string `json:"surname"`
+	Id            int    `json:"id"`
+	AuthToken     string `json:"auth_token"`
+	LoggedInCount int    `json:"logged_in_count"`
 }
 
 type AuthKey struct {
@@ -35,7 +36,7 @@ func (user *User) ToString() string {
 func DbEntryToUser(row *sql.Rows) *User {
 	selectedUser := &User{}
 	for row.Next() {
-		row.Scan(&selectedUser.Id, &selectedUser.Email, &selectedUser.Password, &selectedUser.Name, &selectedUser.Surname, &selectedUser.AuthToken)
+		row.Scan(&selectedUser.Id, &selectedUser.Email, &selectedUser.Password, &selectedUser.Name, &selectedUser.Surname, &selectedUser.AuthToken, &selectedUser.LoggedInCount)
 	}
 	if selectedUser.Name == "" {
 		return nil

--- a/backend/db/migrate.go
+++ b/backend/db/migrate.go
@@ -55,7 +55,8 @@ func createTables(db *sql.DB) {
         "password" TEXT NOT NULL,
         "name" TEXT NOT NULL,
         "surname" TEXT NOT NULL,
-        "auth_token" TEXT
+        "auth_token" TEXT,
+        "logged_in_count" integer NOT NULL
     );`
 	CreatePasswordsTableQuery := `CREATE TABLE password (
         "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,

--- a/backend/db/migrate.go
+++ b/backend/db/migrate.go
@@ -55,8 +55,7 @@ func createTables(db *sql.DB) {
         "password" TEXT NOT NULL,
         "name" TEXT NOT NULL,
         "surname" TEXT NOT NULL,
-        "auth_token" TEXT, 
-        "token_expiry_date" integer
+        "auth_token" TEXT
     );`
 	CreatePasswordsTableQuery := `CREATE TABLE password (
         "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -66,8 +65,15 @@ func createTables(db *sql.DB) {
         FOREIGN KEY(user_id) REFERENCES user(id)
     );`
 
+	CreateAuthTable := `CREATE TABLE auth_key (
+    	"id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    	"ip_addr" TEXT NOT NULL,
+    	"user_token" TEXT NOT NULL,
+    	"client_token" TEXT NOT NULL,
+        "token_expiry_date" integer
+    );`
 
-	log.Println("Creating 'user' tables")
+	log.Println("Creating 'user' table")
 
 	statement, err := db.Prepare(CreateUsersTablesQuery)
 	if err != nil {
@@ -76,7 +82,7 @@ func createTables(db *sql.DB) {
 	}
 	statement.Exec()
 
-	log.Println("Creating 'password' tables")
+	log.Println("Creating 'password' table")
 
 	statement, err = db.Prepare(CreatePasswordsTableQuery)
 	if err != nil {
@@ -84,5 +90,14 @@ func createTables(db *sql.DB) {
 		return
 	}
 	statement.Exec()
+
+	log.Println("Creating 'auth_key' table")
+	statement, err = db.Prepare(CreateAuthTable)
+	if err != nil {
+		log.Fatalf("Error creating 'auth_key' table: %s", err)
+		return
+	}
+	statement.Exec()
+
 	log.Println("All tables created")
 }

--- a/backend/http_helpers.go
+++ b/backend/http_helpers.go
@@ -60,3 +60,6 @@ func ValidateToken(w http.ResponseWriter, r *http.Request) *db.User {
 	return userInformation
 }
 
+func GetRequestIP(r *http.Request) string {
+	return strings.Split(r.RemoteAddr, ":")[0]
+}

--- a/backend/http_helpers.go
+++ b/backend/http_helpers.go
@@ -52,7 +52,7 @@ func ValidateToken(w http.ResponseWriter, r *http.Request) *db.User {
 	}
 	token := strings.Split(tokenHeader, " ")[1]
 
-	userInformation := s.GetUserWithAuthToken(token, GetRequestIP(r))
+	userInformation := s.GetUserWithAuthToken(token)
 	if userInformation == nil {
 		Unauthorized(w)
 		return nil

--- a/backend/http_helpers.go
+++ b/backend/http_helpers.go
@@ -52,7 +52,7 @@ func ValidateToken(w http.ResponseWriter, r *http.Request) *db.User {
 	}
 	token := strings.Split(tokenHeader, " ")[1]
 
-	userInformation := s.GetUserWithAuthToken(token)
+	userInformation := s.GetUserWithAuthToken(token, GetRequestIP(r))
 	if userInformation == nil {
 		Unauthorized(w)
 		return nil


### PR DESCRIPTION
It is now possible to log in, and be logged in to the same account, from multiple devices at the same time.

New structure: 
- user table no longer keeps track of the lifespan of a token
- new `auth_key` table. Stores reference to `user_token` from user table, a new `client_token`, lifespan, and the `ip_addr` of the client